### PR TITLE
Fix v2 lexer rejecting tight inline edge labels (-.text.->)

### DIFF
--- a/src/core/mermaid_v2/parse/lexer.zig
+++ b/src/core/mermaid_v2/parse/lexer.zig
@@ -6,7 +6,9 @@
 //! tokens — the parser handles label interiors itself.
 //!
 //! Edges match greedily as full operators (`-->`, `---`, `==>`, `===`,
-//! `-.->`, `-.-`, `~~~`); the inline-label form `-- text -->` is handled too.
+//! `-.->`, `-.-`, `~~~`); the inline-label forms `-- text -->` and the
+//! tight variants without spaces (`-.text.->`, `--text-->`, `==text==>`)
+//! are handled too.
 
 const std = @import("std");
 
@@ -301,12 +303,15 @@ pub const Lexer = struct {
         return tok;
     }
 
-    /// True when the cursor sits on whitespace that could precede an
-    /// inline edge label (`-- text -->`). Requires at least one space and
-    /// then a non-newline, non-connector character.
+    /// True when the cursor could sit at the start of an inline edge label,
+    /// either after whitespace (`-- text -->`) or tight against the opening
+    /// run (`-.text.->`). Excludes '|' so the pipe-label form (`---|text|`)
+    /// keeps its bail path, and newlines so an unterminated run still bails.
+    /// guarded-by: lexer_test.zig "tight inline label on a dotted edge"
     fn atInlineLabel(self: *Lexer) bool {
         if (self.pos >= self.source.len) return false;
-        return self.source[self.pos] == ' ' or self.source[self.pos] == '\t';
+        const c = self.source[self.pos];
+        return c != '\n' and c != '\r' and c != '|';
     }
 
     /// Consume `   label   <connector-run><arrow>` for the inline-label

--- a/src/core/mermaid_v2/parse/lexer_test.zig
+++ b/src/core/mermaid_v2/parse/lexer_test.zig
@@ -183,6 +183,52 @@ test "inline edge label keeps an embedded dash intact" {
     try t.expectEqual(TokenKind.eof, lx.next().kind);
 }
 
+test "tight inline label on a dotted edge" {
+    // Mermaid accepts labels tight against the connector runs: `A-.text.->B`
+    // is the same edge as `A -. text .-> B`. The opening run here is just
+    // "-." with no arrow, so the lexer must probe for the label even though
+    // no whitespace follows.
+    var lx = Lexer.init("A -.narrates.-> B\n");
+    try t.expectEqualStrings("A", lx.next().text);
+    const e = lx.next();
+    try t.expectEqual(TokenKind.edge_dotted, e.kind);
+    try t.expect(e.edge_label != null);
+    try t.expectEqualStrings("narrates", e.edge_label.?);
+    try t.expectEqualStrings("B", lx.next().text);
+
+    // Labels with interior spaces and dashes stay intact in the tight form.
+    var lx2 = Lexer.init("A -.captured as-we-build.-> B");
+    _ = lx2.next();
+    const e2 = lx2.next();
+    try t.expectEqual(TokenKind.edge_dotted, e2.kind);
+    try t.expectEqualStrings("captured as-we-build", e2.edge_label.?);
+
+    // Tight solid and thick variants take the same path.
+    var lx3 = Lexer.init("A --text--> B");
+    _ = lx3.next();
+    const e3 = lx3.next();
+    try t.expectEqual(TokenKind.edge_solid, e3.kind);
+    try t.expectEqualStrings("text", e3.edge_label.?);
+
+    var lx4 = Lexer.init("A ==text==> B");
+    _ = lx4.next();
+    const e4 = lx4.next();
+    try t.expectEqual(TokenKind.edge_thick, e4.kind);
+    try t.expectEqualStrings("text", e4.edge_label.?);
+
+    // A short run with no closing connector before end-of-line still bails:
+    // "--" followed by an identifier is not an edge.
+    var lx5 = Lexer.init("A --B\n");
+    _ = lx5.next();
+    try t.expect(lx5.next().kind != TokenKind.edge_solid);
+
+    // The pipe-label form keeps its own path: a short run before '|' bails
+    // rather than swallowing the pipe text as an inline label.
+    var lx6 = Lexer.init("A --|text| B\n");
+    _ = lx6.next();
+    try t.expect(lx6.next().kind != TokenKind.edge_solid);
+}
+
 test "solo CR (old Mac line ending) emits a newline token but does not bump the line counter" {
     // Only CRLF collapses into a single line-incrementing newline; a lone
     // '\r' with no following '\n' still tokenizes as .newline (advanceRaw


### PR DESCRIPTION
The v2 lexer rejected the tight dotted-edge inline label form `A-.text.->B`, which mermaid accepts. This teaches the lexer the tight form and adds coverage in `lexer_test.zig`.

Rebased onto the 0.2.0 mercat lineage from the original parser-fix branch (dropped its stale version bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)